### PR TITLE
Change Erigon support for 'trace_rawTransaction'

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Each node client supports a different set of tracers and trace methods.
 | `trace_filter`                  | ❌ | ✅ | ✅ | ✅ | ✅ |
 | `trace_call`                    | ❌ | ✅ | ✅ | ✅ | ✅ |
 | `trace_callMany`                | ❌ | ✅ | ✅ | ✅ | ❌ |
-| `trace_rawTransaction`          | ❌ | ✅ | ✅ | ✅ | ✅ |
+| `trace_rawTransaction`          | ❌ | ✅ | ❌ | ✅ | ✅ |
 | `trace_get`                     | ❌ | ✅ | ✅ | ✅ | ❌ |
 | `debug_traceBlock`              | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `debug_traceTransaction`        | ✅ | ✅ | ✅ | ❌ | ✅ |


### PR DESCRIPTION

## Overview
Erigon doesn not support 'trace_rawTransaction' yet, according to https://github.com/erigontech/erigon/blob/main/cmd/rpcdaemon/README.md?plain=1#L344

## PoC


Input:
```
curl --location 'url'  --header 'Content-Type: application/json' --data '{                
    "jsonrpc": "2.0",
    "method": "trace_rawTransaction",   
    "params": ["0x6ae1f98e148d21a75bb2ea42d11d076c4132e986747a75cd3b6fce5fe049e7aa",["trace","vmTrace","stateDiff"]], "id": 1
}'

```

Output:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32000,
        "message": "the method is currently not implemented: trace_rawTransaction"
    }
}
```